### PR TITLE
anyenv 関連を init から utils へ分離

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ chsh
 anyenv のマニフェストのインストールと, 各 env のインストールを行う。
 
 ```bash
-zsh ~/dotfiles/utils/install-anyenv.sh
+$ zsh ~/dotfiles/utils/install-anyenv.sh
 ```
 
 ## Update

--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ cd ~/dotfiles
 zsh initialize.zsh
 ```
 
+### インストール後
+
+#### ログインシェルを zsh へ切り替え
+
+`chsh` を使い, ログインシェルを `zsh` へ切り替える。
+切り替え後は一旦ログアウトする。
+
+```bash
+$ which zsh
+$ chsh
+```
+
+#### anyenv のセットアップ
+
+anyenv のマニフェストのインストールと, 各 env のインストールを行う。
+
+```bash
+zsh ~/dotfiles/utils/install-anyenv.sh
+```
+
 ## Update
 
 このリポジトリに入っている ``pull-dotfiles`` コマンドを使う。

--- a/init/setup-anyenv.zsh
+++ b/init/setup-anyenv.zsh
@@ -9,7 +9,6 @@ anyenv_bin="${anyenv_dir}/bin/anyenv"
 anyenv_plugins_dir="${anyenv_dir}/plugins"
 anyenv_update_dir="${anyenv_dir}/plugins/anyenv-update"
 export ANYENV_ROOT="${anyenv_dir}"
-export SHELL="zsh"
 
 if [ -d ${anyenv_dir} ]; then
     echo "Directory ${anyenv_dir} is already exist."

--- a/init/setup-anyenv.zsh
+++ b/init/setup-anyenv.zsh
@@ -29,18 +29,5 @@ else
     git clone --depth 1 https://github.com/znz/anyenv-update ${anyenv_update_dir}
 fi
 
-echo "Initialize anyenv"
-eval "$(${anyenv_bin} init zsh --no-rehash)"
-eval "$(${anyenv_bin} install --init)"
-
-echo "Install envs"
-for envname in rbenv phpenv pyenv nodenv; do
-    echo "Install ${envname}"
-    envname_dir="${anyenv_dir}/envs/${envname}"
-    if [ -d ${envname_dir} ];then
-        echo "Directory ${envname_dir} is already exist."
-        echo "Skip install ${envname}."
-    else
-        ${anyenv_bin} install -f ${envname}
-    fi
-done
+echo "Successfully installed anyenv and anyenv-update"
+echo "Please execute 'bash utils/install-anyenv.sh'"

--- a/utils/install-anyenv.sh
+++ b/utils/install-anyenv.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eu
+
+ANYENV_DIR="${HOME}/.anyenv"
+ANYENV_DEFINITION_ROOT="${XDG_CONFIG_HOME:-${HOME}/.config}/anyenv/anyenv-install"
+
+if [ ! -e ${ANYENV_DEFINITION_ROOT} ];then
+    echo "Missing ${ANYENV_DEFINITION_ROOT} !"
+    echo "Run 'anyenv install --init' command"
+    anyenv install --init
+fi
+
+echo "Install envs"
+for envname in rbenv phpenv pyenv nodenv; do
+    echo "Install ${envname}"
+    envname_dir="${ANYENV_DIR}/envs/${envname}"
+
+    if [ -e ${envname_dir} ];then
+        echo "Directory ${envname_dir} is already exist."
+        echo "Skip install ${envname}."
+    else
+        anyenv install ${envname}
+    fi
+done


### PR DESCRIPTION
## 概要

anyenv-install で毎回コケるので, anyenv-install 以降の処理を `utils/install-anyenv.sh` へ分離。

## 変更内容

- `init/setup-anyenv.zsh` から `anyenv-install` と 各種 env のインストール処理を削除
- `anyenv-install` と 各種 env のインストールを実行する `utils/install-anyenv.sh` ファイルを作成

## 影響範囲

- 実行するスクリプトの追加
  - init 実行後, 一旦ログアウトをして zsh から `utils/install-anyenv.sh` を実行する必要がある

## 動作要件

なし

## 補足

なし