### PR TITLE
GitHub Action の Slack Notification の `job_name` で `github.workflow` を使う

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
         uses: homoluctus/slatify@v1.5
         if: always()
         with:
-          job_name: '*dotfiles CI*'
+          job_name: '*${{ github.workflow }}*'
           type: ${{ job.status }}
           icon_emoji: ":octocat:"
           url: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## 概要

GitHub Action の Slack Notification の `job_name` には workflow の名前と同じものを使うので, `github.workflow` を流用する.

## 変更内容

- `main.yml` の `job_name` の書き換え

## 影響範囲

なし

## 動作要件

なし

## 補足

なし