### PR TITLE
defaultBranchをmainに設定

### DIFF
--- a/symlink-files/.gitconfig
+++ b/symlink-files/.gitconfig
@@ -26,3 +26,5 @@
   tags = tag
 [http]
 	sslVerify = false
+[init]
+	defaultBranch = main


### PR DESCRIPTION
## 概要

`defaultBranch`をmainに設定．
GitHubに合わせる．

## 変更内容

`init.defaultBranch`をmainに設定．

## 影響範囲

なし

## 動作要件

Git v2.28.0 以降でのみ適用される

## 補足

なし