### PR TITLE
GitHub Actionsの通知を失敗時のみにする

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Slack Notification
         uses: homoluctus/slatify@v1.5
-        if: always()
+        if: failure()
         with:
           job_name: '*${{ github.workflow }}*'
           type: ${{ job.status }}


### PR DESCRIPTION
# 概要

GitHub Actionsの通知を失敗時のみにする