### PR TITLE
Composerの設定からprestissimoを削除

### DIFF
--- a/symlinks/files/manual-link/.composer/config.json
+++ b/symlinks/files/manual-link/.composer/config.json
@@ -1,9 +1,4 @@
 {
-    "config": {
-        "prestissimo": {
-            "maxConnections": 20
-        }
-    },
     "repositories": {
         "packagist": {
             "type": "composer",


### PR DESCRIPTION
# 概要

Composerの設定からprestissimoを削除。
prestissimoは既に削除したため不要。