### PR TITLE
fix: VCSに追加しうるファイル名をグローバルのgitignoreとhgignoreから削除

### DIFF
--- a/symlinks/files/auto-link/.gitignore_global
+++ b/symlinks/files/auto-link/.gitignore_global
@@ -1,18 +1,11 @@
 # Global gitignore
 
-# Local configure
-.env
-
-# etc
-.vagrant
-
 # OS
 
 ## macOS
 .DS_Store
 .AppleDouble
 .LSOverride
-Icon
 ._*
 .DocumentRevisions-V100
 .fseventsd
@@ -52,16 +45,6 @@ $RECYCLE.BIN/
 
 # Editor, IDE
 
-## JetBrains
-.idea
-
-## Visual Studio Code
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-
 ## Vim
 [._]*.s[a-v][a-z]
 [._]*.sw[a-p]
@@ -82,7 +65,6 @@ Session.vim
 /vendor/
 /.yardoc/
 /_yardoc/
-/doc/
 /rdoc/
 .ruby-version
 .rvmrc

--- a/symlinks/files/auto-link/.hgignore_global
+++ b/symlinks/files/auto-link/.hgignore_global
@@ -1,18 +1,11 @@
 # Global hgignore
 
-# Local configure
-.env
-
-# etc
-.vagrant
-
 # OS
 
 ## macOS
 .DS_Store
 .AppleDouble
 .LSOverride
-Icon
 ._*
 .DocumentRevisions-V100
 .fseventsd
@@ -52,16 +45,6 @@ $RECYCLE.BIN/
 
 # Editor, IDE
 
-## JetBrains
-.idea
-
-## Visual Studio Code
-.vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-
 ## Vim
 [._]*.s[a-v][a-z]
 [._]*.sw[a-p]
@@ -82,7 +65,6 @@ Session.vim
 /vendor/
 /.yardoc/
 /_yardoc/
-/doc/
 /rdoc/
 .ruby-version
 .rvmrc


### PR DESCRIPTION
# 概要

プルリクエストの概要．
